### PR TITLE
fix(footer): copyrightは団体名でありたいので、Oysters Podcast -> Oystersに変更

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -50,7 +50,7 @@
       </div>
     </div>
     <div class="footer-copyright">
-      © 2023 <a href="{{ site.github.url }}/">{{ site.title }}</a>
+      © 2019-2023 <a href="https://oystersjp.github.io">Oysters</a>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
* copyrightは団体名でありたいので、Oysters Podcast -> Oystersに変更
    * URLは https://oystersjp.github.io/ で 
    * https://github.com/oystersjp/oystersjp.github.io