### PR TITLE
Spotify用にfeed情報を少し修正

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -6,13 +6,13 @@
     <atom:link href="{{ site.github.url }}/feed.xml" rel="self" type="application/rss+xml" />
     <link>{{ site.github.url }}/</link>
     <title>{{ site.title }}</title>
-    <description>{{ site.description | xml_escape }}</description>
+    <description>{{ site.description_long | xml_escape }}</description>
     <media:keywords>{{ site.keywords }}</media:keywords>
     <media:category scheme="http://www.itunes.com/dtds/podcast-1.0.dtd">Technology</media:category>
     <language>{{ site.language }}</language>
     <itunes:subtitle>{{ site.description | xml_escape }}</itunes:subtitle>
     <itunes:author>{{ site.author }}</itunes:author>
-    <itunes:summary>{{ site.description | xml_escape }}</itunes:summary>
+    <itunes:summary>{{ site.description_long | xml_escape }}</itunes:summary>
     <itunes:keywords>{{ site.keywords }}</itunes:keywords>
     <itunes:owner>
       <itunes:name>{{ site.author }}</itunes:name>

--- a/feed.xml
+++ b/feed.xml
@@ -26,7 +26,7 @@
         <title>{{ post.title | xml_escape }}</title>
         <link>{{ site.github.url }}{{ post.url }}</link>
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
-        <description>{{ post.content | xml_escape }}</description>
+        <description><h2 id="内容紹介">内容紹介</h2> <p>{{ post.description }}</p> {{ post.content | xml_escape }}</description>
         <guid isPermaLink="true">{{ site.github.url }}{{ post.url }}</guid>
         <enclosure url="{{ site.github.url }}{{ post.audio_file_path }}" length="{{ post.audio_file_size }}" type="audio/mp3"/>
         <itunes:author>{{ site.author }}</itunes:author>


### PR DESCRIPTION
# 何した
* descriptionに内容紹介の情報が何も入っていなかったので追加
* Podcastの紹介内容が少し寂しかったので、longバージョンの方を採用