### PR TITLE
remove(sitemap): 無茶苦茶なsitemapができたので削除

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,3 @@
-plugins:
-  - jekyll-sitemap
 members:
   02:
     image_url: /images/members/02.jpg


### PR DESCRIPTION
本来Topページじゃないpodcastサイトにsitemapをおいたのが原因。おとなしくoysters.github.ioに置く